### PR TITLE
fix: comment out the couch app

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - shipwright build image --repo=npmjs --name=npm-docker-couchdb
+  - shipwright build image --repo=npmjs --name=npm-docker-couchdb --tags=lm,v_s,v,miv,ma,b,b_v_c_s

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ script:
   - 'echo "TODO: add integration tests"'
 
 before_script:
-  - npm i dockyard@latest -g
+  - npm i @npm-wharf/shipwright@latest -g
 
 after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - dockyard build image --repo=npmjs --name=npm-docker-couchdb
+  - shipwright build image --repo=npmjs --name=npm-docker-couchdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ MAINTAINER Ben Coe ben@npmjs.com
 RUN groupadd -r couchdb && useradd -d /var/lib/couchdb -g couchdb couchdb
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    vim \
     ca-certificates \
     curl \
     erlang-nox \

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,8 @@ WORKDIR /var/lib/couchdb
 
 COPY ./start-couchdb.sh /var/lib/couchdb
 COPY ./install-couch-app.sh /var/lib/couchdb
+COPY ./remove-couch-app.sh /var/lib/couchdb
+COPY ./purge-app.js /var/lib/couchdb
 COPY local.ini /usr/local/etc/couchdb/local.d/
 
 RUN npm install npm-registry-couchapp@npmo

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,21 +43,8 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
   && rm /usr/local/bin/tini.asc \
   && chmod +x /usr/local/bin/tini
 
-# https://www.apache.org/dist/couchdb/KEYS
-ENV GPG_KEYS \
-  15DD4F3B8AACA54740EB78C7B7B7C53943ECCEE1 \
-  1CFBFA43C19B6DF4A0CA3934669C02FFDF3CEBA3 \
-  25BBBAC113C1BFD5AA594A4C9F96B92930380381 \
-  4BFCA2B99BADC6F9F105BEC9C5E32E2D6B065BFB \
-  5D680346FAA3E51B29DBCB681015F68F9DA248BC \
-  7BCCEB868313DDA925DF1805ECA5BCB7BB9656B0 \
-  C3F4DFAEAD621E1C94523AEEC376457E61D50B88 \
-  D2B17F9DA23C0A10991AF2E3D9EE01E47852AEE4 \
-  E0AF0A194D55C84E4A19A801CDB0C0F904F4EE9B
 RUN set -xe \
-  && for key in $GPG_KEYS; do \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
-  done
+  && curl -sSL https://downloads.apache.org/couchdb/KEYS | gpg --import -
 
 ENV COUCHDB_VERSION 1.6.1
 
@@ -74,8 +61,8 @@ RUN buildDeps=' \
     make \
   ' \
   && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
-  && curl -fSL http://apache.osuosl.org/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
-  && curl -fSL https://www.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
+  && curl -fSL https://archive.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz -o couchdb.tar.gz \
+  && curl -fSL https://archive.apache.org/dist/couchdb/source/$COUCHDB_VERSION/apache-couchdb-$COUCHDB_VERSION.tar.gz.asc -o couchdb.tar.gz.asc \
   && gpg --verify couchdb.tar.gz.asc \
   && mkdir -p /usr/src/couchdb \
   && tar -xzf couchdb.tar.gz -C /usr/src/couchdb --strip-components=1 \

--- a/local.ini
+++ b/local.ini
@@ -20,7 +20,7 @@ users_db_public = true
 ; example.com:5984 = /database
 
 [vhosts]
-registry.npmjs.org = /registry/_design/app/_rewrite
+; registry.npmjs.org = /registry/_design/app/_rewrite
 
 [update_notification]
 ;unique notifier name=/full/path/to/exe -with "cmd line arg"

--- a/purge-app.js
+++ b/purge-app.js
@@ -3,7 +3,7 @@ const http = require('http')
 
 function deleteDesignDocument (name) {
   console.log('fetching design document:', name)
-  http.request({
+  const getReq = http.request({
     host: 'localhost',
     port: 5984,
     auth: 'admin:admin',
@@ -18,7 +18,7 @@ function deleteDesignDocument (name) {
       res.on('end', () => {
         const parsed = JSON.parse(str)
         console.log('deleting design document:', name, 'at revision', parsed._rev)
-        http.request({
+        const deleteReq = http.request({
           method: 'DELETE',
           host: 'localhost',
           port: 5984,
@@ -32,6 +32,12 @@ function deleteDesignDocument (name) {
             console.log('failed! received unexpected status code:', res.statusCode)
           }
         })
+
+        deleteReq.on('error', (err) => {
+          console.log('failed! received error response')
+          console.log(err.stack)
+        })
+        deleteReq.end()
       })
     } else {
       res.resume()
@@ -39,6 +45,12 @@ function deleteDesignDocument (name) {
       process.exitCode = 1
     }
   })
+
+  getReq.on('error', (err) => {
+    console.log('failed! received error response')
+    console.log(err.stack)
+  })
+  getReq.end()
 }
 
 deleteDesignDocument('app')

--- a/purge-app.js
+++ b/purge-app.js
@@ -1,0 +1,37 @@
+const http = require('http')
+
+
+function deleteDesignDocument (name) {
+  http.request({
+    host: 'localhost',
+    port: 5984,
+    auth: 'admin:admin',
+    path: `/registry/_design/${name}`
+  }, (res) => {
+    if (res.statusCode === 200) {
+      let str = ''
+      res.on('data', (chunk) => {
+        str += chunk
+      })
+
+      res.on('end', () => {
+        const parsed = JSON.parse(str)
+        http.request({
+          method: 'DELETE',
+          host: 'localhost',
+          port: 5984,
+          auth: 'admin:admin',
+          path: `/registry/_design/${name}?rev=${parsed._rev}`
+        }, (deleteRes) => {
+          if (deleteRes.statusCode === 200) {
+            console.log('deleted design doc:', name)
+            deleteRes.resume()
+          }
+        })
+      })
+    }
+  })
+}
+
+deleteDesignDocument('app')
+deleteDesignDocument('scratch')

--- a/purge-app.js
+++ b/purge-app.js
@@ -2,6 +2,7 @@ const http = require('http')
 
 
 function deleteDesignDocument (name) {
+  console.log('fetching design document:', name)
   http.request({
     host: 'localhost',
     port: 5984,
@@ -16,6 +17,7 @@ function deleteDesignDocument (name) {
 
       res.on('end', () => {
         const parsed = JSON.parse(str)
+        console.log('deleting design document:', name, 'at revision', parsed._rev)
         http.request({
           method: 'DELETE',
           host: 'localhost',
@@ -23,12 +25,18 @@ function deleteDesignDocument (name) {
           auth: 'admin:admin',
           path: `/registry/_design/${name}?rev=${parsed._rev}`
         }, (deleteRes) => {
+          deleteRes.resume()
           if (deleteRes.statusCode === 200) {
             console.log('deleted design doc:', name)
-            deleteRes.resume()
+          } else {
+            console.log('failed! received unexpected status code:', res.statusCode)
           }
         })
       })
+    } else {
+      res.resume()
+      console.log('failed! received unexpected status code:', res.statusCode)
+      process.exitCode = 1
     }
   })
 }

--- a/remove-couch-app.sh
+++ b/remove-couch-app.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# wait for CouchDB to be online before we put the documents.
+# note that username and password on CouchDB are both admin.
+until $(curl --output /dev/null --silent --head --fail http://localhost:5984/); do
+    printf '.'
+    sleep 2
+done
+
+node ./purge-app.js

--- a/start-couchdb.sh
+++ b/start-couchdb.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 set -e
-./install-couch-app.sh &
+#./install-couch-app.sh &
+./remove-couch-app.sh &
 couchdb


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

I have identified the existing routes in the npme clusters that depend on the couch app and submitted patches to work around their needs. I also included here a script that will _remove_ the couch app after this container is deployed, which is a large portion of how we are reducing resource usage in couchdb itself.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Related change to frontdoor: https://github.com/npm/registry-frontdoor/pull/437
Related change to storefile-transforms (specifically versions-to-tarballs): https://github.com/npm/storefile-transforms/pull/48
